### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for managing and providing prompts. This server allows users and LLMs to easily add, retrieve, and manage prompt templates stored as markdown files with YAML frontmatter support.
 
+<a href="https://glama.ai/mcp/servers/@tanker327/prompts-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tanker327/prompts-mcp-server/badge" alt="Prompts Server MCP server" />
+</a>
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [Prompts MCP Server](https://glama.ai/mcp/servers/@tanker327/prompts-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tanker327/prompts-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tanker327/prompts-mcp-server/badge" alt="Prompts Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.